### PR TITLE
Fix medianAbsoluteDeviation for mir-algorithm 3.9.6

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -5,7 +5,7 @@ authors "John Michael Hall" "Ilya Yaroshenko"
 copyright "Copyright © 2020, Mir Stat Authors."
 license "BSL-1.0"
 
-dependency "mir-algorithm" version=">=3.9.4"
+dependency "mir-algorithm" version=">=3.9.6"
 
 buildType "unittest" {
     buildOptions "unittests" "debugMode" "debugInfo"

--- a/source/mir/stat/descriptive.d
+++ b/source/mir/stat/descriptive.d
@@ -997,7 +997,7 @@ template medianAbsoluteDeviation(F)
 
         alias G = typeof(return);
         static assert(isFloatingPoint!G, "medianAbsoluteDeviation: output type must be floating point");
-        return slice.move.center!(median!G).map!fabs.median!G;
+        return slice.move.center!(median!(G, false)).map!fabs.median!(G, false);
     }
 }
 


### PR DESCRIPTION
`medianAbsoluteDeviation` got broken with the latest mir-algorithm release. This fixes it. It is likely the problem with the outstanding PRs, but I will need to rebase them after this is merged.