### PR TITLE
Copy latest mir-algorithm travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: false
+os:
+ - linux
 language: d
 d:
  - ldc
@@ -20,8 +23,12 @@ matrix:
     - {d: dmd-nightly}
     - {d: ldc-beta}
     - {d: gdc}
+  include:
+    - {os: linux, env: ARCH="AARCH64", services: docker}
+    - {os: osx, env: ARCH="x86_64", d: ldc}
+    - {os: osx, env: ARCH="x86_64", d: dmd}
 script:
- - travis_wait 100 dub test --arch "$ARCH" --build=unittest-cov
+ - travis_wait 100 bash -e test_travis.sh
 
 after_success:
  - bash <(curl -s https://codecov.io/bash)

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,12 @@
+FROM resin/aarch64-ubuntu
+RUN apt-get update && apt-get -y install xz-utils libxml2 gcc git pkg-config ninja-build python3-pip
+RUN pip3 install meson
+RUN curl -fsSLO https://github.com/ldc-developers/ldc/releases/download/v1.24.0/ldc2-1.24.0-linux-aarch64.tar.xz \
+ && tar xf ldc2-1.24.0-linux-aarch64.tar.xz \
+ && sudo cp -rf ldc2-1.24.0-linux-aarch64/* /usr/local \
+ && rm -rf ldc*
+COPY source source
+COPY include include
+COPY meson.build meson.build
+COPY subprojects subprojects
+RUN ls subprojects && meson build -D with_test_explicit=true --default-library=static && ninja test -C build

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('mir-stat', 'd', version : '0.0.0', license: 'BSL-1.0')
+project('mir-stat', 'd', version : '0.0.5', license: 'BSL-1.0')
 
 description = 'Dlang Statistical Package'
 

--- a/test_travis.sh
+++ b/test_travis.sh
@@ -1,0 +1,10 @@
+echo $ARCH
+if [ "$ARCH" = "AARCH64" ]
+then
+  docker run --rm --privileged multiarch/qemu-user-static:register --reset
+  docker build -t ion-arm64 . -f Dockerfile.aarch64
+else
+  echo $ARCH
+  dub test --arch=$ARCH --build=unittest-dip1000
+  dub test --arch=$ARCH --build=unittest-cov
+fi


### PR DESCRIPTION
CI is not running in [PR #24](https://github.com/libmir/mir-stat/pull/24). Attempting to copy latest `.travis.yml` from `mir-algorithm`.