### PR TITLE
Fix code block

### DIFF
--- a/source/mir/stat/descriptive.d
+++ b/source/mir/stat/descriptive.d
@@ -51,9 +51,8 @@ All sample quantiles are defined as weighted averages of consecutive order
 statistics. For each QuantileAlgo, the sample quantile is given by
 (using R's 1-based indexing notation):
 
--------
-(1 - `gamma`) * `x$(SUBSCRIPT j)` + `gamma` * `x$(SUBSCRIPT j + 1)`
--------
+    (1 - `gamma`) * `x$(SUBSCRIPT j)` + `gamma` * `x$(SUBSCRIPT j + 1)`
+
 
 where `x$(SUBSCRIPT j)` is the `j`th order statistic. `gamma` is a function of
 `j = floor(np + m)` and `g = np + m - j` where `n` is the sample size, `p` is


### PR DESCRIPTION
The prior commit's adjustment to the documentation was within a code block, which does not render properly. Removing code block here to fix.

Ideally, there would be a $(CENTER ...) macro that could display this a bit better. It doesn't really make sense to have it as a $(BLOCKQUOTE ...).