### PR TITLE
Fix builtin complex deprecations, switch to mir.complex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ docgen
 _build_dir_
 .VSCodeCounter
 mir-stat-test-library
+*.pdb

--- a/dub.sdl
+++ b/dub.sdl
@@ -5,16 +5,16 @@ authors "John Michael Hall" "Ilya Yaroshenko"
 copyright "Copyright © 2020, Mir Stat Authors."
 license "BSL-1.0"
 
-dependency "mir-algorithm" version=">=3.9.60"
+dependency "mir-algorithm" version=">=3.12.30"
 
 buildType "unittest" {
     buildOptions "unittests" "debugMode" "debugInfo"
-    versions "mir_stat_test" "mir_stat_test_bultincomplex"
+    versions "mir_stat_test" "mir_stat_test_mircomplex" "mir_stat_test_stdcomplex"
     dflags "-lowmem"
 }
 buildType "unittest-cov" {
     buildOptions "unittests" "coverage" "debugMode" "debugInfo"
-    versions "mir_stat_test" "mir_stat_test_bultincomplex"
+    versions "mir_stat_test" "mir_stat_test_complex" "mir_stat_test_stdcomplex"
     dflags "-lowmem"
 }
 buildType "unittest-release" {

--- a/source/mir/math/internal/powi.d
+++ b/source/mir/math/internal/powi.d
@@ -62,11 +62,13 @@ Unqual!T powi(T)(T x, size_t i)
     }
 }
 
-version(mir_stat_test_builtincomplex)
+version(mir_stat_test_mircomplex)
 @safe pure nothrow
 unittest
 {
-    cdouble x = 1.0 + 2.0i;
+    import mir.complex;
+    alias C = Complex!double;
+    auto x = C(1, 2);
     assert(x.powi(0) == 0);
     assert(x.powi(1) == x);
 }

--- a/source/mir/stat/package.d
+++ b/source/mir/stat/package.d
@@ -5,7 +5,7 @@ License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: John Michael Hall, Ilya Yaroshenko
 
-Copyright: 2020 Mir Stat Authors.
+Copyright: 2022 Mir Stat Authors.
 
 Macros:
 SUBREF = $(REF_ALTTEXT $(TT $2), $2, mir, stat, $1)$(NBSP)

--- a/source/mir/stat/transform.d
+++ b/source/mir/stat/transform.d
@@ -6,7 +6,7 @@ License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: John Michael Hall, Ilya Yaroshenko
 
-Copyright: 2020 Mir Stat Authors.
+Copyright: 2022 Mir Stat Authors.
 
 Macros:
 SUBREF = $(REF_ALTTEXT $(TT $2), $2, mir, stat, $1)$(NBSP)


### PR DESCRIPTION
I left in some code related to `std.complex`, happy to remove if preferred.