### PR TITLE
Add normal distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ docgen
 _build_dir_
 .VSCodeCounter
 mir-stat-test-library
+*.pdb

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2022 Mir Stat Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dub.sdl
+++ b/dub.sdl
@@ -2,8 +2,8 @@ name "mir-stat"
 description "Dlang Statistical Package"
 
 authors "John Michael Hall" "Ilya Yaroshenko"
-copyright "Copyright © 2020, Mir Stat Authors."
-license "BSL-1.0"
+copyright "Copyright © 2022, Mir Stat Authors."
+license "Apache-2.0"
 
 dependency "mir-algorithm" version=">=3.12.30"
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -5,16 +5,16 @@ authors "John Michael Hall" "Ilya Yaroshenko"
 copyright "Copyright © 2020, Mir Stat Authors."
 license "BSL-1.0"
 
-dependency "mir-algorithm" version=">=3.9.60"
+dependency "mir-algorithm" version=">=3.12.30"
 
 buildType "unittest" {
     buildOptions "unittests" "debugMode" "debugInfo"
-    versions "mir_stat_test" "mir_stat_test_bultincomplex"
+    versions "mir_stat_test" "mir_stat_test_mircomplex" "mir_stat_test_stdcomplex"
     dflags "-lowmem"
 }
 buildType "unittest-cov" {
     buildOptions "unittests" "coverage" "debugMode" "debugInfo"
-    versions "mir_stat_test" "mir_stat_test_bultincomplex"
+    versions "mir_stat_test" "mir_stat_test_complex" "mir_stat_test_stdcomplex"
     dflags "-lowmem"
 }
 buildType "unittest-release" {

--- a/index.d
+++ b/index.d
@@ -14,6 +14,11 @@ $(BOOKTABLE ,
     $(TR $(TDNW $(MREF mir,stat)) $(TD Publicly imports `mir.stat.*` modules ))
     $(TR $(TDNW $(MREF mir,stat,descriptive)) $(TD Descriptive statistics ))
     $(TR $(TDNW $(MREF mir,stat,transform)) $(TD Algorithms for transforming data ))
+    $(TR $(TDNW $(MREF mir,stat,distribution)) $(TD Statistical Distributions (WIP) ))
+    $(TR $(TDNW $(MREF mir,stat,distribution,pdf)) $(TD Probability Density Functions (WIP) ))
+    $(TR $(TDNW $(MREF mir,stat,distribution,cdf)) $(TD Cumulative Distribution Functions (WIP) ))
+    $(TR $(TDNW $(MREF mir,stat,distribution,invcdf)) $(TD Inverse Cumulative Distribution Functions (WIP) ))
+    $(TR $(TDNW $(MREF mir,stat,distribution,normal)) $(TD Normal Distribution ))
 )
 
 Macros:

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('mir-stat', 'd', version : '0.0.0', license: 'BSL-1.0')
+project('mir-stat', 'd', version : '0.0.10', license: 'BSL-1.0')
 
 description = 'Dlang Statistical Package'
 
@@ -11,6 +11,11 @@ sources_list = [
     'mir/stat/descriptive',
     'mir/stat/package',
     'mir/stat/transform',
+    'mir/stat/distribution/package',
+    'mir/stat/distribution/cdf',
+    'mir/stat/distribution/pdf',
+    'mir/stat/distribution/invcdf',
+    'mir/stat/distribution/normal',
 ]
 
 sources = []

--- a/source/mir/math/internal/powi.d
+++ b/source/mir/math/internal/powi.d
@@ -62,11 +62,13 @@ Unqual!T powi(T)(T x, size_t i)
     }
 }
 
-version(mir_stat_test_builtincomplex)
+version(mir_stat_test_mircomplex)
 @safe pure nothrow
 unittest
 {
-    cdouble x = 1.0 + 2.0i;
+    import mir.complex;
+    alias C = Complex!double;
+    auto x = C(1, 2);
     assert(x.powi(0) == 0);
     assert(x.powi(1) == x);
 }

--- a/source/mir/math/internal/powi.d
+++ b/source/mir/math/internal/powi.d
@@ -1,9 +1,9 @@
 /++
-License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
 
 Authors: John Michael Hall
 
-Copyright: 2020 Mir Stat Authors.
+Copyright: 2022 Mir Stat Authors.
 +/
 
 module mir.math.internal.powi;

--- a/source/mir/stat/descriptive.d
+++ b/source/mir/stat/descriptive.d
@@ -1,7 +1,7 @@
 /++
 This module contains algorithms for descriptive statistics.
 
-License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
 
 Authors: John Michael Hall, Ilya Yaroshenko
 

--- a/source/mir/stat/distribution/cdf.d
+++ b/source/mir/stat/distribution/cdf.d
@@ -1,0 +1,14 @@
+/++
+This package publicly imports `mir.stat.distribution.*CDF` modules.
+
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
+
+Authors: John Michael Hall, Ilya Yaroshenko
+
+Copyright: 2022 Mir Stat Authors.
+
++/
+
+module mir.stat.distribution.cdf;
+
+public import mir.stat.distribution.normal: normalCDF;

--- a/source/mir/stat/distribution/invcdf.d
+++ b/source/mir/stat/distribution/invcdf.d
@@ -1,0 +1,14 @@
+/++
+This package publicly imports `mir.stat.distribution.*InvCDF` modules.
+
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
+
+Authors: John Michael Hall, Ilya Yaroshenko
+
+Copyright: 2022 Mir Stat Authors.
+
++/
+
+module mir.stat.distribution.invcdf;
+
+public import mir.stat.distribution.normal: normalInvCDF;

--- a/source/mir/stat/distribution/normal.d
+++ b/source/mir/stat/distribution/normal.d
@@ -1,0 +1,22 @@
+/**
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
+*/
+/**
+ * Normal Distribution
+ *
+ * Copyright: Based on the CEPHES math library, which is
+ *            Copyright (C) 1994 Stephen L. Moshier (moshier@world.std.com).
+ * Authors:   Stephen L. Moshier, ported to D by Don Clugston and David Nadlinger. Adopted to Mir by Ilya Yaroshenko.
+ */
+/**
+ * Macros:
+ *  NAN = $(RED NAN)
+ *  INTEGRAL = &#8747;
+ *  POWER = $1<sup>$2</sup>
+ *      <caption>Special Values</caption>
+ *      $0</table>
+ */
+
+module mir.stat.distribution.normal;
+
+public import mir.math.func.normal: normalPDF, normalCDF, normalInvCDF;

--- a/source/mir/stat/distribution/package.d
+++ b/source/mir/stat/distribution/package.d
@@ -1,0 +1,14 @@
+/++
+This package publicly imports `mir.stat.distribution.*` modules.
+
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
+
+Authors: John Michael Hall, Ilya Yaroshenko
+
+Copyright: 2022 Mir Stat Authors.
+
++/
+
+module mir.stat.distribution;
+
+public import mir.stat.distribution.normal;

--- a/source/mir/stat/distribution/pdf.d
+++ b/source/mir/stat/distribution/pdf.d
@@ -1,0 +1,14 @@
+/++
+This package publicly imports `mir.stat.distribution.*PDF` modules.
+
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
+
+Authors: John Michael Hall, Ilya Yaroshenko
+
+Copyright: 2022 Mir Stat Authors.
+
++/
+
+module mir.stat.distribution.pdf;
+
+public import mir.stat.distribution.normal: normalPDF;

--- a/source/mir/stat/package.d
+++ b/source/mir/stat/package.d
@@ -5,7 +5,7 @@ License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: John Michael Hall, Ilya Yaroshenko
 
-Copyright: 2020 Mir Stat Authors.
+Copyright: 2022 Mir Stat Authors.
 
 Macros:
 SUBREF = $(REF_ALTTEXT $(TT $2), $2, mir, stat, $1)$(NBSP)

--- a/source/mir/stat/package.d
+++ b/source/mir/stat/package.d
@@ -1,7 +1,7 @@
 /++
 This package publicly imports `mir.stat.*` modules.
 
-License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
 
 Authors: John Michael Hall, Ilya Yaroshenko
 

--- a/source/mir/stat/package.d
+++ b/source/mir/stat/package.d
@@ -20,3 +20,4 @@ module mir.stat;
 
 public import mir.stat.descriptive;
 public import mir.stat.transform;
+public import mir.stat.distribution;

--- a/source/mir/stat/transform.d
+++ b/source/mir/stat/transform.d
@@ -2,7 +2,7 @@
 This module contains algorithms for transforming data that are useful in
 statistical applications.
 
-License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
 
 Authors: John Michael Hall, Ilya Yaroshenko
 

--- a/source/mir/stat/transform.d
+++ b/source/mir/stat/transform.d
@@ -6,7 +6,7 @@ License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: John Michael Hall, Ilya Yaroshenko
 
-Copyright: 2020 Mir Stat Authors.
+Copyright: 2022 Mir Stat Authors.
 
 Macros:
 SUBREF = $(REF_ALTTEXT $(TT $2), $2, mir, stat, $1)$(NBSP)


### PR DESCRIPTION
This PR also includes a general structure for adding future distributions. The idea is to have multiple ways to get the functions so that if the user just needs functions from one distribution, then they can import from there. If they just need pdfs or cdfs, then they can import just those files.

A next step is to work on adding the other distributions as I have time.

Will tag after this PR is merged. 