### PR TITLE
Add uniform probability distribution

### DIFF
--- a/index.d
+++ b/index.d
@@ -20,7 +20,8 @@ $(BOOKTABLE ,
     $(TR $(TDNW $(MREF mir,stat,distribution,pdf)) $(TD Probability Density Functions (WIP) ))
     $(TR $(TDNW $(MREF mir,stat,distribution,cdf)) $(TD Cumulative Distribution Functions (WIP) ))
     $(TR $(TDNW $(MREF mir,stat,distribution,invcdf)) $(TD Inverse Cumulative Distribution Functions (WIP) ))
-    $(TR $(TDNW $(MREF mir,stat,distribution,normal)) $(TD Normal Distribution ))
+    $(TR $(TDNW $(MREF mir,stat,distribution,normal)) $(TD Normal Probability Distribution ))
+    $(TR $(TDNW $(MREF mir,stat,distribution,uniform)) $(TD Uniform Probability Distribution ))
 )
 
 Macros:

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ sources_list = [
     'mir/stat/distribution/pdf',
     'mir/stat/distribution/invcdf',
     'mir/stat/distribution/normal',
+    'mir/stat/distribution/uniform',
 ]
 
 sources = []

--- a/source/mir/stat/distribution/cdf.d
+++ b/source/mir/stat/distribution/cdf.d
@@ -12,3 +12,4 @@ Copyright: 2022 Mir Stat Authors.
 module mir.stat.distribution.cdf;
 
 public import mir.stat.distribution.normal: normalCDF;
+public import mir.stat.distribution.uniform: uniformCDF;

--- a/source/mir/stat/distribution/invcdf.d
+++ b/source/mir/stat/distribution/invcdf.d
@@ -12,3 +12,4 @@ Copyright: 2022 Mir Stat Authors.
 module mir.stat.distribution.invcdf;
 
 public import mir.stat.distribution.normal: normalInvCDF;
+public import mir.stat.distribution.uniform: uniformInvCDF;

--- a/source/mir/stat/distribution/package.d
+++ b/source/mir/stat/distribution/package.d
@@ -12,3 +12,4 @@ Copyright: 2022 Mir Stat Authors.
 module mir.stat.distribution;
 
 public import mir.stat.distribution.normal;
+public import mir.stat.distribution.uniform;

--- a/source/mir/stat/distribution/pdf.d
+++ b/source/mir/stat/distribution/pdf.d
@@ -12,3 +12,4 @@ Copyright: 2022 Mir Stat Authors.
 module mir.stat.distribution.pdf;
 
 public import mir.stat.distribution.normal: normalPDF;
+public import mir.stat.distribution.uniform: uniformPDF;

--- a/source/mir/stat/distribution/uniform.d
+++ b/source/mir/stat/distribution/uniform.d
@@ -24,6 +24,7 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
+@safe pure nothrow @nogc
 T uniformPDF(T)(const T x, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
     in(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution")
@@ -54,6 +55,7 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
+@safe pure nothrow @nogc
 T uniformCDF(T)(const T x, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
     in(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution")
@@ -84,6 +86,7 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
+@safe pure nothrow @nogc
 T uniformCCDF(T)(const T x, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
     in(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution")
@@ -114,6 +117,7 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
+@safe pure nothrow @nogc
 T uniformInvCDF(T)(const T p, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
     in(p >= 0, "p must be greater than or equal to 0")
@@ -144,6 +148,7 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
+@safe pure nothrow @nogc
 T uniformLPDF(T)(const T x, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
     in(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution")
@@ -178,6 +183,7 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
+@safe pure nothrow @nogc
 T uniformLuPDF(T)(const T x, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
     in(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution")

--- a/source/mir/stat/distribution/uniform.d
+++ b/source/mir/stat/distribution/uniform.d
@@ -169,36 +169,3 @@ unittest {
     assert(0.5.uniformLPDF(0.0, 1.5).approxEqual(-log(1.5)));
     assert(1.5.uniformLPDF(1.0, 3.0).approxEqual(-log(2.0)));
 }
-
-/++
-Computes the uniform log unnormalized probability distribution function (LuPDF)
-
-This removes constants that would typically get dropped in estimation.
-
-Params:
-    x = value to evaluate LuPDF
-    lower = lower bound
-    upper = upper bound
-
-See_also:
-    $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
-+/
-@safe pure nothrow @nogc
-T uniformLuPDF(T)(const T x, const T lower = 0, const T upper = 1)
-    if (isFloatingPoint!T)
-    in(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution")
-    in(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution")
-    in(lower < upper, "lower must be less than upper")
-{
-    return cast(T) 1;
-}
-
-///
-version(mir_stat_test)
-@safe pure nothrow @nogc
-unittest {
-    import mir.math.common: approxEqual, log;
-    assert(0.5.uniformLuPDF == 1);
-    assert(0.5.uniformLuPDF(0.0, 1.5) == 1);
-    assert(2.5.uniformLuPDF(1.0, 3.0) == 1);
-}

--- a/source/mir/stat/distribution/uniform.d
+++ b/source/mir/stat/distribution/uniform.d
@@ -24,13 +24,12 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
-T uniformPDF(T)(T x, T lower = 0, T upper = 1)
+T uniformPDF(T)(const T x, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
+    in(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution")
+    in(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution")
+    in(lower < upper, "lower must be less than upper")
 {
-    assert(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution.");
-    assert(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution.");
-    assert(lower < upper, "lower must be less than upper");
-
     return 1.0L / (upper - lower);
 }
 
@@ -55,13 +54,12 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
-T uniformCDF(T)(T x, T lower = 0, T upper = 1)
+T uniformCDF(T)(const T x, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
+    in(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution")
+    in(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution")
+    in(lower < upper, "lower must be less than upper")
 {
-    assert(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution.");
-    assert(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution.");
-    assert(lower < upper, "lower must be less than upper");
-
     return (x - lower) / (upper - lower);
 }
 
@@ -86,13 +84,12 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
-T uniformCCDF(T)(T x, T lower = 0, T upper = 1)
+T uniformCCDF(T)(const T x, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
+    in(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution")
+    in(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution")
+    in(lower < upper, "lower must be less than upper")
 {
-    assert(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution.");
-    assert(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution.");
-    assert(lower < upper, "lower must be less than upper");
-
     return (upper - x) / (upper - lower);
 }
 
@@ -117,13 +114,12 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
-T uniformInvCDF(T)(T p, T lower = 0, T upper = 1)
+T uniformInvCDF(T)(const T p, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
+    in(p >= 0, "p must be greater than or equal to 0")
+    in(p <= 1, "p must be less than or equal to 1")
+    in(lower < upper, "lower must be less than upper")
 {
-    assert(p >= 0, "p must be greater than or equal to 0.");
-    assert(p <= 1, "p must be less than or equal to 1.");
-    assert(lower < upper, "lower must be less than upper");
-
     return lower + p * (upper - lower);
 }
 
@@ -148,13 +144,12 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
-T uniformLPDF(T)(T x, T lower = 0, T upper = 1)
+T uniformLPDF(T)(const T x, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
+    in(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution")
+    in(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution")
+    in(lower < upper, "lower must be less than upper")
 {
-    assert(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution.");
-    assert(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution.");
-    assert(lower < upper, "lower must be less than upper");
-
     import mir.math.common: log;
 
     return -log(upper - lower);
@@ -183,13 +178,12 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
 +/
-T uniformLuPDF(T)(T x, T lower = 0, T upper = 1)
+T uniformLuPDF(T)(const T x, const T lower = 0, const T upper = 1)
     if (isFloatingPoint!T)
+    in(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution")
+    in(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution")
+    in(lower < upper, "lower must be less than upper")
 {
-    assert(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution.");
-    assert(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution.");
-    assert(lower < upper, "lower must be less than upper");
-
     return cast(T) 1;
 }
 

--- a/source/mir/stat/distribution/uniform.d
+++ b/source/mir/stat/distribution/uniform.d
@@ -1,0 +1,204 @@
+/++
+This module contains algorithms for the uniform continuous probability distribution.
+
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
+
+Authors: John Michael Hall
+
+Copyright: 2022 Mir Stat Authors.
+
++/
+
+module mir.stat.distribution.uniform;
+
+import mir.internal.utility: isFloatingPoint;
+
+/++
+Computes the uniform probability distribution function (PDF).
+
+Params:
+    x = value to evaluate PDF
+    lower = lower bound
+    upper = upper bound
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
++/
+T uniformPDF(T)(T x, T lower = 0, T upper = 1)
+    if (isFloatingPoint!T)
+{
+    assert(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution.");
+    assert(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution.");
+    assert(lower < upper, "lower must be less than upper");
+
+    return 1.0L / (upper - lower);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+    assert(0.5.uniformPDF == 1);
+    assert(0.5.uniformPDF(0.0, 1.5).approxEqual(2.0 / 3));
+    assert(2.5.uniformPDF(1.0, 3.0).approxEqual(0.5));
+}
+
+/++
+Computes the uniform cumulative distribution function (CDF).
+
+Params:
+    x = value to evaluate CDF
+    lower = lower bound
+    upper = upper bound
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
++/
+T uniformCDF(T)(T x, T lower = 0, T upper = 1)
+    if (isFloatingPoint!T)
+{
+    assert(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution.");
+    assert(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution.");
+    assert(lower < upper, "lower must be less than upper");
+
+    return (x - lower) / (upper - lower);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+    assert(0.5.uniformCDF == 0.5);
+    assert(0.5.uniformCDF(0.0, 1.5).approxEqual(1.0 / 3));
+    assert(2.5.uniformCDF(1.0, 3.0).approxEqual(3.0 / 4));
+}
+
+/++
+Computes the uniform complementary cumulative distribution function (CCDF).
+
+Params:
+    x = value to evaluate CCDF
+    lower = lower bound
+    upper = upper bound
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
++/
+T uniformCCDF(T)(T x, T lower = 0, T upper = 1)
+    if (isFloatingPoint!T)
+{
+    assert(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution.");
+    assert(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution.");
+    assert(lower < upper, "lower must be less than upper");
+
+    return (upper - x) / (upper - lower);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+    assert(0.5.uniformCCDF == 0.5);
+    assert(0.5.uniformCCDF(0.0, 1.5).approxEqual(2.0 / 3));
+    assert(2.5.uniformCCDF(1.0, 3.0).approxEqual(1.0 / 4));
+}
+
+/++
+Computes the uniform inverse cumulative distribution function (InvCDF)
+
+Params:
+    p = value to evaluate InvCDF
+    lower = lower bound
+    upper = upper bound
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
++/
+T uniformInvCDF(T)(T p, T lower = 0, T upper = 1)
+    if (isFloatingPoint!T)
+{
+    assert(p >= 0, "p must be greater than or equal to 0.");
+    assert(p <= 1, "p must be less than or equal to 1.");
+    assert(lower < upper, "lower must be less than upper");
+
+    return lower + p * (upper - lower);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+    assert(0.5.uniformInvCDF == 0.5);
+    assert((1.0 / 3).uniformInvCDF(0.0, 1.5).approxEqual(0.5));
+    assert((3.0 / 4).uniformInvCDF(1.0, 3.0).approxEqual(2.5));
+}
+
+/++
+Computes the uniform log probability distribution function (LPDF)
+
+Params:
+    x = value to evaluate LPDF
+    lower = lower bound
+    upper = upper bound
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
++/
+T uniformLPDF(T)(T x, T lower = 0, T upper = 1)
+    if (isFloatingPoint!T)
+{
+    assert(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution.");
+    assert(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution.");
+    assert(lower < upper, "lower must be less than upper");
+
+    import mir.math.common: log;
+
+    return -log(upper - lower);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual, log;
+    assert(0.5.uniformLPDF == 0);
+    assert(0.5.uniformLPDF(0.0, 1.5).approxEqual(-log(1.5)));
+    assert(1.5.uniformLPDF(1.0, 3.0).approxEqual(-log(2.0)));
+}
+
+/++
+Computes the uniform log unnormalized probability distribution function (LuPDF)
+
+This removes constants that would typically get dropped in estimation.
+
+Params:
+    x = value to evaluate LuPDF
+    lower = lower bound
+    upper = upper bound
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Continuous_uniform_distribution, uniform probability distribution)
++/
+T uniformLuPDF(T)(T x, T lower = 0, T upper = 1)
+    if (isFloatingPoint!T)
+{
+    assert(x >= lower, "x must be greater than or equal to lower bound in uniform probability distribution.");
+    assert(x <= upper, "x must be less than or equal to upper bound in uniform probability distribution.");
+    assert(lower < upper, "lower must be less than upper");
+
+    return cast(T) 1;
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual, log;
+    assert(0.5.uniformLuPDF == 1);
+    assert(0.5.uniformLuPDF(0.0, 1.5) == 1);
+    assert(2.5.uniformLuPDF(1.0, 3.0) == 1);
+}


### PR DESCRIPTION
Adds the uniform probability distribution.

I am also including log-likelihood functions (LPDF and LuPDF, the latter removes the constants, used for maximum likelihood). 

I took the approach of including default parameters for `lower` and `upper`, rather than the approach taken in `mir.math.func.normal` of using separate functions for the default case. I am happy to change that if you think necessary, but I figured that it would probably get inlined. 