### PR TITLE
Add beta probability distribution

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -5,7 +5,7 @@ authors "John Michael Hall" "Ilya Yaroshenko"
 copyright "Copyright © 2022, Mir Stat Authors."
 license "Apache-2.0"
 
-dependency "mir-algorithm" version=">=3.12.36"
+dependency "mir-algorithm" version=">=3.12.37"
 
 buildType "unittest" {
     buildOptions "unittests" "debugMode" "debugInfo"

--- a/index.d
+++ b/index.d
@@ -20,6 +20,7 @@ $(BOOKTABLE ,
     $(TR $(TDNW $(MREF mir,stat,distribution,pdf)) $(TD Probability Density Functions (WIP) ))
     $(TR $(TDNW $(MREF mir,stat,distribution,cdf)) $(TD Cumulative Distribution Functions (WIP) ))
     $(TR $(TDNW $(MREF mir,stat,distribution,invcdf)) $(TD Inverse Cumulative Distribution Functions (WIP) ))
+    $(TR $(TDNW $(MREF mir,stat,distribution,beta)) $(TD Beta Probability Distribution ))
     $(TR $(TDNW $(MREF mir,stat,distribution,normal)) $(TD Normal Probability Distribution ))
     $(TR $(TDNW $(MREF mir,stat,distribution,uniform)) $(TD Uniform Probability Distribution ))
 )

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ has_cpp_headers = false
 
 sources_list = [
     'mir/math/internal/powi',
+    'mir/math/internal/logBeta',
     'mir/stat/descriptive/package',
     'mir/stat/descriptive/univariate',
     'mir/stat/descriptive/weighted',
@@ -17,6 +18,7 @@ sources_list = [
     'mir/stat/distribution/cdf',
     'mir/stat/distribution/pdf',
     'mir/stat/distribution/invcdf',
+    'mir/stat/distribution/beta',
     'mir/stat/distribution/normal',
     'mir/stat/distribution/uniform',
 ]

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ has_cpp_headers = false
 
 sources_list = [
     'mir/math/internal/powi',
-    'mir/math/internal/logBeta',
+    'mir/math/internal/log_beta',
     'mir/stat/descriptive/package',
     'mir/stat/descriptive/univariate',
     'mir/stat/descriptive/weighted',

--- a/source/mir/math/internal/logBeta.d
+++ b/source/mir/math/internal/logBeta.d
@@ -1,0 +1,32 @@
+/++
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
+
+Authors: John Michael Hall
+
+Copyright: 2022 Mir Stat Authors.
++/
+
+module mir.math.internal.logBeta;
+
+import mir.internal.utility: isFloatingPoint;
+
+package(mir)
+@safe pure nothrow @nogc
+T logBeta(T)(const T alpha, const T beta)
+    if (isFloatingPoint!T)
+{
+    import std.mathspecial: logGamma;
+
+    return logGamma(alpha) + logGamma(beta) - logGamma(alpha + beta);
+}
+
+version(mir_stat_test)
+@safe pure nothrow
+unittest
+{
+    import mir.math.common: approxEqual, log;
+    import std.mathspecial: beta;
+
+    assert(logBeta(1.0, 2).approxEqual(log(beta(1.0, 2))));
+    assert(logBeta(0.5, 4).approxEqual(log(beta(0.5, 4))));
+}

--- a/source/mir/math/internal/log_beta.d
+++ b/source/mir/math/internal/log_beta.d
@@ -12,7 +12,7 @@ import mir.internal.utility: isFloatingPoint;
 
 package(mir)
 @safe pure nothrow @nogc
-T log_beta(T)(const T alpha, const T beta)
+T logBeta(T)(const T alpha, const T beta)
     if (isFloatingPoint!T)
 {
     import std.mathspecial: logGamma;
@@ -27,6 +27,6 @@ unittest
     import mir.math.common: approxEqual, log;
     import std.mathspecial: beta;
 
-    assert(log_beta(1.0, 2).approxEqual(log(beta(1.0, 2))));
-    assert(log_beta(0.5, 4).approxEqual(log(beta(0.5, 4))));
+    assert(logBeta(1.0, 2).approxEqual(log(beta(1.0, 2))));
+    assert(logBeta(0.5, 4).approxEqual(log(beta(0.5, 4))));
 }

--- a/source/mir/math/internal/log_beta.d
+++ b/source/mir/math/internal/log_beta.d
@@ -6,13 +6,13 @@ Authors: John Michael Hall
 Copyright: 2022 Mir Stat Authors.
 +/
 
-module mir.math.internal.logBeta;
+module mir.math.internal.log_beta;
 
 import mir.internal.utility: isFloatingPoint;
 
 package(mir)
 @safe pure nothrow @nogc
-T logBeta(T)(const T alpha, const T beta)
+T log_beta(T)(const T alpha, const T beta)
     if (isFloatingPoint!T)
 {
     import std.mathspecial: logGamma;
@@ -27,6 +27,6 @@ unittest
     import mir.math.common: approxEqual, log;
     import std.mathspecial: beta;
 
-    assert(logBeta(1.0, 2).approxEqual(log(beta(1.0, 2))));
-    assert(logBeta(0.5, 4).approxEqual(log(beta(0.5, 4))));
+    assert(log_beta(1.0, 2).approxEqual(log(beta(1.0, 2))));
+    assert(log_beta(0.5, 4).approxEqual(log(beta(0.5, 4))));
 }

--- a/source/mir/stat/distribution/beta.d
+++ b/source/mir/stat/distribution/beta.d
@@ -165,7 +165,7 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
 +/
-@safe pure nothrow @nogc
+@safe nothrow @nogc
 T betaLPDF(T)(const T x, const T alpha, const T beta)
     if (isFloatingPoint!T)
     in(x >= 0, "x must be greater than or equal to 0")
@@ -175,13 +175,14 @@ T betaLPDF(T)(const T x, const T alpha, const T beta)
 {
     import mir.math.common: log;
     import mir.math.internal.log_beta: log_beta;
+    import core.stdc.tgmath: log1p;
 
-    return (alpha - 1) * log(x) + (beta - 1) * log(1 - x) - log_beta(alpha, beta);
+    return (alpha - 1) * log(x) + (beta - 1) * log1p(-x) - log_beta(alpha, beta);
 }
 
 ///
 version(mir_stat_test)
-@safe pure nothrow @nogc
+@safe nothrow @nogc
 unittest {
     import mir.math.common: approxEqual, log;
 

--- a/source/mir/stat/distribution/beta.d
+++ b/source/mir/stat/distribution/beta.d
@@ -165,7 +165,7 @@ Params:
 See_also:
     $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
 +/
-@safe nothrow @nogc
+@safe pure nothrow @nogc
 T betaLPDF(T)(const T x, const T alpha, const T beta)
     if (isFloatingPoint!T)
     in(x >= 0, "x must be greater than or equal to 0")
@@ -175,14 +175,14 @@ T betaLPDF(T)(const T x, const T alpha, const T beta)
 {
     import mir.math.common: log;
     import mir.math.internal.log_beta: log_beta;
-    import core.stdc.tgmath: log1p;
+    import std.math.exponential: log1p;
 
     return (alpha - 1) * log(x) + (beta - 1) * log1p(-x) - log_beta(alpha, beta);
 }
 
 ///
 version(mir_stat_test)
-@safe nothrow @nogc
+@safe pure nothrow @nogc
 unittest {
     import mir.math.common: approxEqual, log;
 

--- a/source/mir/stat/distribution/beta.d
+++ b/source/mir/stat/distribution/beta.d
@@ -1,0 +1,191 @@
+/++
+This module contains algorithms for the beta probability distribution.
+
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
+
+Authors: John Michael Hall
+
+Copyright: 2022 Mir Stat Authors.
+
++/
+
+module mir.stat.distribution.beta;
+
+import mir.internal.utility: isFloatingPoint;
+
+/++
+Computes the beta probability distribution function (PDF).
+
+Params:
+    x = value to evaluate PDF
+    alpha = shape parameter #1
+    beta = shape parameter #2
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
++/
+@safe pure nothrow @nogc
+T betaPDF(T)(const T x, const T alpha, const T beta)
+    if (isFloatingPoint!T)
+    in(x >= 0, "x must be greater than or equal to 0")
+    in(x <= 1, "x must be less than or equal to 1")
+    in(alpha > 0, "alpha must be greater than zero")
+    in(beta > 0, "beta must be greater than zero")
+{
+    import mir.math.common: pow;
+    import std.mathspecial: betaFunc = beta;
+
+    return pow(x, (alpha - 1)) * pow((1 - x), (beta - 1)) / betaFunc(alpha, beta);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+
+    assert(0.5.betaPDF(1, 1) == 1);
+    assert(0.75.betaPDF(1, 2).approxEqual(0.5));
+    assert(0.25.betaPDF(0.5, 4).approxEqual(0.9228516));
+}
+
+/++
+Computes the beta cumulatve distribution function (CDF).
+
+Params:
+    x = value to evaluate CDF
+    alpha = shape parameter #1
+    beta = shape parameter #2
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
++/
+@safe pure nothrow @nogc
+T betaCDF(T)(const T x, const T alpha, const T beta)
+    if (isFloatingPoint!T)
+    in(x >= 0, "x must be greater than or equal to 0")
+    in(x <= 1, "x must be less than or equal to 1")
+    in(alpha > 0, "alpha must be greater than zero")
+    in(beta > 0, "beta must be greater than zero")
+{
+    import std.mathspecial: betaIncomplete;
+
+    return betaIncomplete(alpha, beta, x);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+
+    assert(0.5.betaCDF(1, 1).approxEqual(0.5));
+    assert(0.75.betaCDF(1, 2).approxEqual(0.9375));
+    assert(0.25.betaCDF(0.5, 4).approxEqual(0.8588867));
+}
+
+/++
+Computes the beta complementary cumulative distribution function (CCDF).
+
+Params:
+    x = value to evaluate CCDF
+    alpha = shape parameter #1
+    beta = shape parameter #2
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
++/
+@safe pure nothrow @nogc
+T betaCCDF(T)(const T x, const T alpha, const T beta)
+    if (isFloatingPoint!T)
+    in(x >= 0, "x must be greater than or equal to 0")
+    in(x <= 1, "x must be less than or equal to 1")
+    in(alpha > 0, "alpha must be greater than zero")
+    in(beta > 0, "beta must be greater than zero")
+{
+    import std.mathspecial: betaIncomplete;
+
+    return betaIncomplete(beta, alpha, 1 - x);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+
+    assert(0.5.betaCCDF(1, 1).approxEqual(0.5));
+    assert(0.75.betaCCDF(1, 2).approxEqual(0.0625));
+    assert(0.25.betaCCDF(0.5, 4).approxEqual(0.1411133));
+}
+
+/++
+Computes the beta inverse cumulative distribution function (InvCDF).
+
+Params:
+    p = value to evaluate InvCDF
+    alpha = shape parameter #1
+    beta = shape parameter #2
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
++/
+@safe pure nothrow @nogc
+T betaInvCDF(T)(const T p, const T alpha, const T beta)
+    if (isFloatingPoint!T)
+    in(p >= 0, "p must be greater than or equal to 0")
+    in(p <= 1, "p must be less than or equal to 1")
+    in(alpha > 0, "alpha must be greater than zero")
+    in(beta > 0, "beta must be greater than zero")
+{
+    import std.mathspecial: betaIncompleteInverse;
+
+    return betaIncompleteInverse(alpha, beta, p);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+
+    assert(0.5.betaInvCDF(1, 1).approxEqual(0.5));
+    assert(0.9375.betaInvCDF(1, 2).approxEqual(0.75));
+    assert(0.8588867.betaInvCDF(0.5, 4).approxEqual(0.25));
+}
+
+/++
+Computes the beta log probability distribution function (LPDF).
+
+Params:
+    x = value to evaluate LPDF
+    alpha = shape parameter #1
+    beta = shape parameter #2
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
++/
+@safe pure nothrow @nogc
+T betaLPDF(T)(const T x, const T alpha, const T beta)
+    if (isFloatingPoint!T)
+    in(x >= 0, "x must be greater than or equal to 0")
+    in(x <= 1, "x must be less than or equal to 1")
+    in(alpha > 0, "alpha must be greater than zero")
+    in(beta > 0, "beta must be greater than zero")
+{
+    import mir.math.common: log;
+    import mir.math.internal.logBeta: logBeta;
+
+    return (alpha - 1) * log(x) + (beta - 1) * log(1 - x) - logBeta(alpha, beta);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual, log;
+
+    assert(0.5.betaLPDF(1, 1).approxEqual(log(betaPDF(0.5, 1, 1))));
+    assert(0.75.betaLPDF(1, 2).approxEqual(log(betaPDF(0.75, 1, 2))));
+    assert(0.25.betaLPDF(0.5, 4).approxEqual(log(betaPDF(0.25, 0.5, 4))));
+}

--- a/source/mir/stat/distribution/beta.d
+++ b/source/mir/stat/distribution/beta.d
@@ -174,9 +174,9 @@ T betaLPDF(T)(const T x, const T alpha, const T beta)
     in(beta > 0, "beta must be greater than zero")
 {
     import mir.math.common: log;
-    import mir.math.internal.logBeta: logBeta;
+    import mir.math.internal.log_beta: log_beta;
 
-    return (alpha - 1) * log(x) + (beta - 1) * log(1 - x) - logBeta(alpha, beta);
+    return (alpha - 1) * log(x) + (beta - 1) * log(1 - x) - log_beta(alpha, beta);
 }
 
 ///

--- a/source/mir/stat/distribution/beta.d
+++ b/source/mir/stat/distribution/beta.d
@@ -174,10 +174,10 @@ T betaLPDF(T)(const T x, const T alpha, const T beta)
     in(beta > 0, "beta must be greater than zero")
 {
     import mir.math.common: log;
-    import mir.math.internal.log_beta: log_beta;
+    import mir.math.internal.log_beta: logBeta;
     import std.math.exponential: log1p;
 
-    return (alpha - 1) * log(x) + (beta - 1) * log1p(-x) - log_beta(alpha, beta);
+    return (alpha - 1) * log(x) + (beta - 1) * log1p(-x) - logBeta(alpha, beta);
 }
 
 ///

--- a/source/mir/stat/distribution/cdf.d
+++ b/source/mir/stat/distribution/cdf.d
@@ -12,6 +12,8 @@ Copyright: 2022 Mir Stat Authors.
 module mir.stat.distribution.cdf;
 
 ///
+public import mir.stat.distribution.beta: betaCDF;
+///
 public import mir.stat.distribution.normal: normalCDF;
 ///
 public import mir.stat.distribution.uniform: uniformCDF;

--- a/source/mir/stat/distribution/invcdf.d
+++ b/source/mir/stat/distribution/invcdf.d
@@ -12,6 +12,9 @@ Copyright: 2022 Mir Stat Authors.
 module mir.stat.distribution.invcdf;
 
 ///
+public import mir.stat.distribution.beta: betaInvCDF;
+///
 public import mir.stat.distribution.normal: normalInvCDF;
 ///
 public import mir.stat.distribution.uniform: uniformInvCDF;
+

--- a/source/mir/stat/distribution/package.d
+++ b/source/mir/stat/distribution/package.d
@@ -12,6 +12,8 @@ Copyright: 2022 Mir Stat Authors.
 module mir.stat.distribution;
 
 ///
+public import mir.stat.distribution.beta;
+///
 public import mir.stat.distribution.normal;
 ///
 public import mir.stat.distribution.uniform;

--- a/source/mir/stat/distribution/pdf.d
+++ b/source/mir/stat/distribution/pdf.d
@@ -12,6 +12,8 @@ Copyright: 2022 Mir Stat Authors.
 module mir.stat.distribution.pdf;
 
 ///
+public import mir.stat.distribution.beta: betaPDF;
+///
 public import mir.stat.distribution.normal: normalPDF;
 ///
 public import mir.stat.distribution.uniform: uniformPDF;


### PR DESCRIPTION
I make use of the `std.mathspecial` functions from phobos as I have no special insight on how to implement these any differently (very similar to the approach used in dstats, [here](https://github.com/DlangScience/dstats/blob/master/source/dstats/distrib.d)). 