### PR TITLE
Log updates

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ has_cpp_headers = false
 sources_list = [
     'mir/math/internal/powi',
     'mir/math/internal/log_beta',
+    'mir/math/internal/xlogy',
     'mir/stat/descriptive/package',
     'mir/stat/descriptive/univariate',
     'mir/stat/descriptive/weighted',

--- a/source/mir/math/internal/xlogy.d
+++ b/source/mir/math/internal/xlogy.d
@@ -1,0 +1,57 @@
+/++
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
+
+Authors: John Michael Hall
+
+Copyright: 2022 Mir Stat Authors.
++/
+
+module mir.math.internal.xlogy;
+
+import mir.internal.utility: isFloatingPoint;
+
+package(mir)
+@safe pure nothrow @nogc
+T xlogy(T)(const T x, const T y)
+    if (isFloatingPoint!T)
+{
+    import mir.math.common: log;
+
+    if (x == 0)
+        return 0;
+    else
+        return x * log(y);
+}
+
+version(mir_stat_test)
+@safe pure nothrow
+unittest
+{
+    import mir.math.common: approxEqual, log;
+
+    assert(xlogy(0.0, 2) == 0);
+    assert(xlogy(0.5, 4).approxEqual(0.5 * log(4.0)));
+}
+
+package(mir)
+@safe pure nothrow @nogc
+T xlog1py(T)(const T x, const T y)
+    if (isFloatingPoint!T)
+{
+    import std.math.exponential: log1p;
+
+    if (x == 0)
+        return 0;
+    else
+        return x * log1p(y);
+}
+
+version(mir_stat_test)
+@safe pure nothrow
+unittest
+{
+    import mir.math.common: approxEqual, log;
+
+    assert(xlog1py(0.0, 2) == 0);
+    assert(xlog1py(0.5, 4).approxEqual(0.5 * log(1 + 4.0)));
+}

--- a/source/mir/stat/distribution/beta.d
+++ b/source/mir/stat/distribution/beta.d
@@ -173,11 +173,10 @@ T betaLPDF(T)(const T x, const T alpha, const T beta)
     in(alpha > 0, "alpha must be greater than zero")
     in(beta > 0, "beta must be greater than zero")
 {
-    import mir.math.common: log;
     import mir.math.internal.log_beta: logBeta;
-    import std.math.exponential: log1p;
+    import mir.math.internal.xlogy: xlogy, xlog1py;
 
-    return (alpha - 1) * log(x) + (beta - 1) * log1p(-x) - logBeta(alpha, beta);
+    return xlogy(alpha - 1, x) + xlog1py(beta - 1, -x) - logBeta(alpha, beta);
 }
 
 ///

--- a/source/mir/stat/distribution/normal.d
+++ b/source/mir/stat/distribution/normal.d
@@ -93,6 +93,9 @@ unittest {
     assert(9.0.normalCCDF(1, 4).approxEqual(1 - normalCDF(9.0, 1, 4)));
 }
 
+///
+enum real LOGSQRT2PI = 0.91893853320467274178032973640561764L; // log(sqrt(2pi))
+
 /++
 Computes the normal log probability distribution function (LPDF)
 
@@ -117,10 +120,9 @@ T normalLPDF(T)(const T x, const T mean, const T stdDev)
 T normalLPDF(T)(const T x)
     if (isFloatingPoint!T)
 {
-    import mir.math.common: log, pow;
-    import mir.math.func.normal: SQRT2PI;
+    import mir.math.common: pow;
 
-    return -0.5 * pow(x, 2) - log(T(SQRT2PI));
+    return -0.5 * pow(x, 2) - T(LOGSQRT2PI);
 }
 
 ///


### PR DESCRIPTION
Addresses feedback from #43 to add an enum for log(sqrt(2pi)). I added as many digits for log(sqrt(2pi)) as are in mir-algorithm for sqrt(2pi) using Wolfram Alpha.

The second commit adds specialization for xlogy/xlog1py. This can generate better code when x=0. 