### PR TITLE
Add beta proportion distribution

### DIFF
--- a/index.d
+++ b/index.d
@@ -21,7 +21,7 @@ $(BOOKTABLE ,
     $(TR $(TDNW $(MREF mir,stat,distribution,cdf)) $(TD Cumulative Distribution Functions (WIP) ))
     $(TR $(TDNW $(MREF mir,stat,distribution,invcdf)) $(TD Inverse Cumulative Distribution Functions (WIP) ))
     $(TR $(TDNW $(MREF mir,stat,distribution,beta)) $(TD Beta Probability Distribution ))
-    $(TR $(TDNW $(MREF mir,stat,distribution,betaProportion)) $(TD Beta Proportion Probability Distribution ))
+    $(TR $(TDNW $(MREF mir,stat,distribution,beta_proportion)) $(TD Beta Proportion Probability Distribution ))
     $(TR $(TDNW $(MREF mir,stat,distribution,normal)) $(TD Normal Probability Distribution ))
     $(TR $(TDNW $(MREF mir,stat,distribution,uniform)) $(TD Uniform Probability Distribution ))
 )

--- a/index.d
+++ b/index.d
@@ -21,6 +21,7 @@ $(BOOKTABLE ,
     $(TR $(TDNW $(MREF mir,stat,distribution,cdf)) $(TD Cumulative Distribution Functions (WIP) ))
     $(TR $(TDNW $(MREF mir,stat,distribution,invcdf)) $(TD Inverse Cumulative Distribution Functions (WIP) ))
     $(TR $(TDNW $(MREF mir,stat,distribution,beta)) $(TD Beta Probability Distribution ))
+    $(TR $(TDNW $(MREF mir,stat,distribution,betaProportion)) $(TD Beta Proportion Probability Distribution ))
     $(TR $(TDNW $(MREF mir,stat,distribution,normal)) $(TD Normal Probability Distribution ))
     $(TR $(TDNW $(MREF mir,stat,distribution,uniform)) $(TD Uniform Probability Distribution ))
 )

--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,7 @@ sources_list = [
     'mir/stat/distribution/pdf',
     'mir/stat/distribution/invcdf',
     'mir/stat/distribution/beta',
-    'mir/stat/distribution/betaProportion',
+    'mir/stat/distribution/beta_proportion',
     'mir/stat/distribution/normal',
     'mir/stat/distribution/uniform',
 ]

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ sources_list = [
     'mir/stat/distribution/pdf',
     'mir/stat/distribution/invcdf',
     'mir/stat/distribution/beta',
+    'mir/stat/distribution/betaProportion',
     'mir/stat/distribution/normal',
     'mir/stat/distribution/uniform',
 ]

--- a/source/mir/stat/distribution/betaProportion.d
+++ b/source/mir/stat/distribution/betaProportion.d
@@ -1,0 +1,204 @@
+/++
+This module contains algorithms for the beta proportion probability distribution.
+
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
+
+Authors: John Michael Hall
+
+Copyright: 2022 Mir Stat Authors.
+
++/
+
+module mir.stat.distribution.betaProportion;
+
+import mir.internal.utility: isFloatingPoint;
+
+/++
+Computes the beta proportion probability distribution function (PDF).
+
+Params:
+    x = value to evaluate PDF
+    mu = shape parameter #1
+    kappa = shape parameter #2
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
++/
+@safe pure nothrow @nogc
+T betaProportionPDF(T)(const T x, const T mu, const T kappa)
+    if (isFloatingPoint!T)
+    in(x >= 0, "x must be greater than or equal to 0")
+    in(x <= 1, "x must be less than or equal to 1")
+    in(mu > 0, "mu must be greater than zero")
+    in(mu < 1, "mu must be less than one")
+    in(kappa > 0, "kappa must be greater than zero")
+{
+    import mir.stat.distribution.beta: betaPDF;
+
+    immutable T alpha = mu * kappa;
+    immutable T beta = kappa - alpha;
+    return betaPDF(x, alpha, beta);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+
+    assert(0.5.betaProportionPDF(0.5, 2) == 1);
+    assert(0.75.betaProportionPDF((1.0 / 3), 3).approxEqual(0.5));
+    assert(0.25.betaProportionPDF((1.0 / 9), 4.5).approxEqual(0.9228516));
+}
+
+/++
+Computes the beta proportion cumulatve distribution function (CDF).
+
+Params:
+    x = value to evaluate CDF
+    mu = shape parameter #1
+    kappa = shape parameter #2
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
++/
+@safe pure nothrow @nogc
+T betaProportionCDF(T)(const T x, const T mu, const T kappa)
+    if (isFloatingPoint!T)
+    in(x >= 0, "x must be greater than or equal to 0")
+    in(x <= 1, "x must be less than or equal to 1")
+    in(mu > 0, "mu must be greater than zero")
+    in(mu < 1, "mu must be less than one")
+    in(kappa > 0, "kappa must be greater than zero")
+{
+    import mir.stat.distribution.beta: betaCDF;
+
+    immutable T alpha = mu * kappa;
+    immutable T beta = kappa - alpha;
+    return betaCDF(x, alpha, beta);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+
+    assert(0.5.betaProportionCDF(0.5, 2).approxEqual(0.5));
+    assert(0.75.betaProportionCDF((1.0 / 3), 3).approxEqual(0.9375));
+    assert(0.25.betaProportionCDF((1.0 / 9), 4.5).approxEqual(0.8588867));
+}
+
+/++
+Computes the beta proportion complementary cumulative distribution function (CCDF).
+
+Params:
+    x = value to evaluate CCDF
+    mu = shape parameter #1
+    kappa = shape parameter #2
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
++/
+@safe pure nothrow @nogc
+T betaProportionCCDF(T)(const T x, const T mu, const T kappa)
+    if (isFloatingPoint!T)
+    in(x >= 0, "x must be greater than or equal to 0")
+    in(x <= 1, "x must be less than or equal to 1")
+    in(mu > 0, "mu must be greater than zero")
+    in(mu < 1, "mu must be less than one")
+    in(kappa > 0, "kappa must be greater than zero")
+{
+    import mir.stat.distribution.beta: betaCCDF;
+
+    immutable T alpha = mu * kappa;
+    immutable T beta = kappa - alpha;
+    return betaCCDF(x, alpha, beta);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+
+    assert(0.5.betaProportionCCDF(0.5, 2).approxEqual(0.5));
+    assert(0.75.betaProportionCCDF((1.0 / 3), 3).approxEqual(0.0625));
+    assert(0.25.betaProportionCCDF((1.0 / 9), 4.5).approxEqual(0.1411133));
+}
+
+/++
+Computes the beta proportion inverse cumulative distribution function (InvCDF).
+
+Params:
+    p = value to evaluate InvCDF
+    mu = shape parameter #1
+    kappa = shape parameter #2
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
++/
+@safe pure nothrow @nogc
+T betaProportionInvCDF(T)(const T p, const T mu, const T kappa)
+    if (isFloatingPoint!T)
+    in(p >= 0, "p must be greater than or equal to 0")
+    in(p <= 1, "p must be less than or equal to 1")
+    in(mu > 0, "mu must be greater than zero")
+    in(mu < 1, "mu must be less than one")
+    in(kappa > 0, "kappa must be greater than zero")
+{
+    import mir.stat.distribution.beta: betaInvCDF;
+
+    immutable T alpha = mu * kappa;
+    immutable T beta = kappa - alpha;
+    return betaInvCDF(p, alpha, beta);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual;
+
+    assert(0.5.betaProportionInvCDF(0.5, 2).approxEqual(0.5));
+    assert(0.9375.betaProportionInvCDF((1.0 / 3), 3).approxEqual(0.75));
+    assert(0.8588867.betaProportionInvCDF((1.0 / 9), 4.5).approxEqual(0.25));
+}
+
+/++
+Computes the beta proportion log probability distribution function (LPDF).
+
+Params:
+    x = value to evaluate LPDF
+    mu = shape parameter #1
+    kappa = shape parameter #2
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Beta_distribution, beta probability distribution)
++/
+@safe pure nothrow @nogc
+T betaProportionLPDF(T)(const T x, const T mu, const T kappa)
+    if (isFloatingPoint!T)
+    in(x >= 0, "x must be greater than or equal to 0")
+    in(x <= 1, "x must be less than or equal to 1")
+    in(mu > 0, "mu must be greater than zero")
+    in(mu < 1, "mu must be less than one")
+    in(kappa > 0, "kappa must be greater than zero")
+{
+    import mir.stat.distribution.beta: betaLPDF;
+
+    immutable T alpha = mu * kappa;
+    immutable T beta = kappa - alpha;
+    return betaLPDF(x, alpha, beta);
+}
+
+///
+version(mir_stat_test)
+@safe pure nothrow @nogc
+unittest {
+    import mir.math.common: approxEqual, log;
+
+    assert(0.5.betaProportionLPDF(0.5, 2).approxEqual(log(betaProportionPDF(0.5, 0.5, 2))));
+    assert(0.75.betaProportionLPDF((1.0 / 3), 3).approxEqual(log(betaProportionPDF(0.75, (1.0 / 3), 3))));
+    assert(0.25.betaProportionLPDF((1.0 / 9), 4.5).approxEqual(log(betaProportionPDF(0.25, (1.0 / 9), 4.5))));
+}

--- a/source/mir/stat/distribution/beta_proportion.d
+++ b/source/mir/stat/distribution/beta_proportion.d
@@ -9,7 +9,7 @@ Copyright: 2022 Mir Stat Authors.
 
 +/
 
-module mir.stat.distribution.betaProportion;
+module mir.stat.distribution.beta_proportion;
 
 import mir.internal.utility: isFloatingPoint;
 

--- a/source/mir/stat/distribution/cdf.d
+++ b/source/mir/stat/distribution/cdf.d
@@ -14,7 +14,7 @@ module mir.stat.distribution.cdf;
 ///
 public import mir.stat.distribution.beta: betaCDF;
 ///
-public import mir.stat.distribution.betaProportion: betaProportionCDF;
+public import mir.stat.distribution.beta_proportion: betaProportionCDF;
 ///
 public import mir.stat.distribution.normal: normalCDF;
 ///

--- a/source/mir/stat/distribution/cdf.d
+++ b/source/mir/stat/distribution/cdf.d
@@ -14,6 +14,8 @@ module mir.stat.distribution.cdf;
 ///
 public import mir.stat.distribution.beta: betaCDF;
 ///
+public import mir.stat.distribution.betaProportion: betaProportionCDF;
+///
 public import mir.stat.distribution.normal: normalCDF;
 ///
 public import mir.stat.distribution.uniform: uniformCDF;

--- a/source/mir/stat/distribution/invcdf.d
+++ b/source/mir/stat/distribution/invcdf.d
@@ -14,7 +14,7 @@ module mir.stat.distribution.invcdf;
 ///
 public import mir.stat.distribution.beta: betaInvCDF;
 ///
-public import mir.stat.distribution.betaProportion: betaProportionInvCDF;
+public import mir.stat.distribution.beta_proportion: betaProportionInvCDF;
 ///
 public import mir.stat.distribution.normal: normalInvCDF;
 ///

--- a/source/mir/stat/distribution/invcdf.d
+++ b/source/mir/stat/distribution/invcdf.d
@@ -14,6 +14,8 @@ module mir.stat.distribution.invcdf;
 ///
 public import mir.stat.distribution.beta: betaInvCDF;
 ///
+public import mir.stat.distribution.betaProportion: betaProportionInvCDF;
+///
 public import mir.stat.distribution.normal: normalInvCDF;
 ///
 public import mir.stat.distribution.uniform: uniformInvCDF;

--- a/source/mir/stat/distribution/package.d
+++ b/source/mir/stat/distribution/package.d
@@ -14,6 +14,8 @@ module mir.stat.distribution;
 ///
 public import mir.stat.distribution.beta;
 ///
+public import mir.stat.distribution.betaProportion;
+///
 public import mir.stat.distribution.normal;
 ///
 public import mir.stat.distribution.uniform;

--- a/source/mir/stat/distribution/package.d
+++ b/source/mir/stat/distribution/package.d
@@ -14,7 +14,7 @@ module mir.stat.distribution;
 ///
 public import mir.stat.distribution.beta;
 ///
-public import mir.stat.distribution.betaProportion;
+public import mir.stat.distribution.beta_proportion;
 ///
 public import mir.stat.distribution.normal;
 ///

--- a/source/mir/stat/distribution/pdf.d
+++ b/source/mir/stat/distribution/pdf.d
@@ -14,7 +14,7 @@ module mir.stat.distribution.pdf;
 ///
 public import mir.stat.distribution.beta: betaPDF;
 ///
-public import mir.stat.distribution.betaProportion: betaProportionPDF;
+public import mir.stat.distribution.beta_proportion: betaProportionPDF;
 ///
 public import mir.stat.distribution.normal: normalPDF;
 ///

--- a/source/mir/stat/distribution/pdf.d
+++ b/source/mir/stat/distribution/pdf.d
@@ -14,6 +14,8 @@ module mir.stat.distribution.pdf;
 ///
 public import mir.stat.distribution.beta: betaPDF;
 ///
+public import mir.stat.distribution.betaProportion: betaProportionPDF;
+///
 public import mir.stat.distribution.normal: normalPDF;
 ///
 public import mir.stat.distribution.uniform: uniformPDF;


### PR DESCRIPTION
This is an alternate parameterization of the beta distribution that can be more convenient to work with sometimes. For instance, it is available in [Stan](https://mc-stan.org/docs/2_29/functions-reference/beta-proportion-distribution.html).