### PR TITLE
Add Cornish-Fisher Expansion

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -5,7 +5,7 @@ authors "John Michael Hall" "Ilya Yaroshenko"
 copyright "Copyright © 2022, Mir Stat Authors."
 license "Apache-2.0"
 
-dependency "mir-algorithm" version=">=3.14.10"
+dependency "mir-algorithm" version=">=3.14.19"
 
 buildType "unittest" {
     buildOptions "unittests" "debugMode" "debugInfo"

--- a/index.d
+++ b/index.d
@@ -26,6 +26,7 @@ $(BOOKTABLE ,
     $(TR $(TDNW $(MREF mir,stat,distribution,beta_proportion)) $(TD Beta Proportion Probability Distribution ))
     $(TR $(TDNW $(MREF mir,stat,distribution,binomial)) $(TD Binomial Probability Distribution ))
     $(TR $(TDNW $(MREF mir,stat,distribution,chi2)) $(TD Chi-squared Probability Distribution ))
+    $(TR $(TDNW $(MREF mir,stat,distribution,cornisher_fisher)) $(TD Cornish-Fisher Expansion ))
     $(TR $(TDNW $(MREF mir,stat,distribution,exponential)) $(TD Exponential Probability Distribution ))
     $(TR $(TDNW $(MREF mir,stat,distribution,gamma)) $(TD Gamma Probability Distribution ))
     $(TR $(TDNW $(MREF mir,stat,distribution,geometric)) $(TD Geometric Probability Distribution ))

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ sources_list = [
     'mir/stat/distribution/beta',
     'mir/stat/distribution/beta_proportion',
     'mir/stat/distribution/binomial',
+    'mir/stat/distribution/cornish_fisher',
     'mir/stat/distribution/exponential',
     'mir/stat/distribution/geometric',
     'mir/stat/distribution/negative_binomial',

--- a/source/mir/stat/distribution/cornish_fisher.d
+++ b/source/mir/stat/distribution/cornish_fisher.d
@@ -1,0 +1,120 @@
+/++
+This module contains algorithms for the Cornish-Fisher expansion
+
+License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
+
+Authors: John Michael Hall
+
+Copyright: 2022 Mir Stat Authors.
++/
+
+module mir.stat.distribution.cornish_fisher;
+
+import mir.internal.utility: isFloatingPoint;
+
+/++
+Approximates the inverse CDF of a continuous distribution using the Cornish-Fisher expansion.
+
+It is generally recommended to only use the Cornish-Fisher expansion with
+distributions that are similar to the normal distribution. Extreme values of
+`skewness` or `excessKurtosis` can result in poorer approximations.
+
+Params:
+    p = quantile to calculate inverse CDF
+    mu = mean
+    std = standard deviation
+    skewness = skewness
+    excessKurtosis = excess kurtosis (kurtosis - 3)
+
+See_also:
+    $(LINK2 https://en.wikipedia.org/wiki/Cornish%E2%80%93Fisher_expansion, Cornish-Fisher Expansion)
++/
+T cornishFisherInvCDF(T)(const T p, const T mu, const T std, const T skewness, const T excessKurtosis)
+    if (isFloatingPoint!T)
+{
+    return mu + std * cornishFisherInvCDF(p, skewness, excessKurtosis);
+}
+
+///
+version(mir_stat_test)
+@safe pure @nogc nothrow
+unittest {
+    import mir.test: shouldApprox;
+
+    0.99.cornishFisherInvCDF(0, 1, 0.1, 1).shouldApprox == 2.629904;
+    0.99.cornishFisherInvCDF(0.1, 0.2, 0.1, 1).shouldApprox == 0.6259808;
+}
+
+/++
+Ditto, but assumes mu = 0 and std = 1
+
+Params:
+    p = quantile to calculate inverse CDF
+    skewness = skewness (default = 0)
+    excessKurtosis = excess kurtosis (kurtosis - 3) (default = 0)
++/
+T cornishFisherInvCDF(T)(const T p, const T skewness = 0, const T excessKurtosis = 0)
+    if (isFloatingPoint!T)
+{
+    import mir.stat.distribution.normal: normalInvCDF;
+
+    T x = normalInvCDF(p);
+    return x.cornishFisherInvCDFImpl(skewness, excessKurtosis);
+}
+
+///
+version(mir_stat_test)
+@safe pure @nogc nothrow
+unittest {
+    import mir.test: shouldApprox;
+
+    0.5.cornishFisherInvCDF.shouldApprox == 0;
+    0.5.cornishFisherInvCDF(1).shouldApprox == -0.1666667;
+    0.5.cornishFisherInvCDF(-1, 0).shouldApprox == 0.1666667;
+
+    0.9.cornishFisherInvCDF(0.1, 0).shouldApprox == 1.292868;
+    0.9.cornishFisherInvCDF(0.1, 1).shouldApprox ==  1.220374;
+    0.9.cornishFisherInvCDF(0.1, -1).shouldApprox == 1.365363;
+
+    0.99.cornishFisherInvCDF(0.1, 0).shouldApprox == 2.396116;
+    0.99.cornishFisherInvCDF(0.1, 1).shouldApprox == 2.629904;
+    0.99.cornishFisherInvCDF(0.1, -1).shouldApprox == 2.162328;
+
+    0.01.cornishFisherInvCDF(0.1, 0).shouldApprox == -2.249053  ;
+    0.01.cornishFisherInvCDF(0.1, 1).shouldApprox == -2.482841;
+    0.01.cornishFisherInvCDF(0.1, -1).shouldApprox == -2.015265;
+}
+
+package(mir.stat)
+T cornishFisherInvCDFImpl(T)(const T x, const T skewness, const T excessKurtosis)
+    if (isFloatingPoint!T)
+{
+    import mir.stat.distribution.normal: normalInvCDF;
+
+    T x2 = x * x;
+    T x3 = x2 * x;
+    return x + (x2 - 1) * skewness / 6 + (x3 - 3 * x) * excessKurtosis / 24 - (2 * x3 - 5 * x) * skewness * skewness / 36;
+}
+
+///
+version(mir_stat_test)
+@safe pure @nogc nothrow
+unittest {
+    import mir.test: shouldApprox;
+
+    0.0.cornishFisherInvCDFImpl(0, 0).shouldApprox == 0;
+    0.0.cornishFisherInvCDFImpl(1, 0).shouldApprox == -0.1666667;
+    0.0.cornishFisherInvCDFImpl(-1, 0).shouldApprox == 0.1666667;
+
+    1.281552.cornishFisherInvCDFImpl(0.1, 0).shouldApprox == 1.292868;
+    1.281552.cornishFisherInvCDFImpl(0.1, 1).shouldApprox ==  1.220374;
+    1.281552.cornishFisherInvCDFImpl(0.1, -1).shouldApprox == 1.365363;
+
+    2.326348.cornishFisherInvCDFImpl(0.1, 0).shouldApprox == 2.396116;
+    2.326348.cornishFisherInvCDFImpl(0.1, 1).shouldApprox == 2.629904;
+    2.326348.cornishFisherInvCDFImpl(0.1, -1).shouldApprox == 2.162328;
+
+    (-2.326348).cornishFisherInvCDFImpl(0.1, 0).shouldApprox == -2.249053  ;
+    (-2.326348).cornishFisherInvCDFImpl(0.1, 1).shouldApprox == -2.482841;
+    (-2.326348).cornishFisherInvCDFImpl(0.1, -1).shouldApprox == -2.015265;
+}

--- a/source/mir/stat/distribution/cornish_fisher.d
+++ b/source/mir/stat/distribution/cornish_fisher.d
@@ -96,7 +96,7 @@ T cornishFisherInvCDFImpl(T)(const T x, const T skewness, const T excessKurtosis
     return x + (x2 - 1) * skewness / 6 + (x3 - 3 * x) * excessKurtosis / 24 - (2 * x3 - 5 * x) * skewness * skewness / 36;
 }
 
-///
+//
 version(mir_stat_test)
 @safe pure @nogc nothrow
 unittest {

--- a/source/mir/stat/distribution/invcdf.d
+++ b/source/mir/stat/distribution/invcdf.d
@@ -22,6 +22,8 @@ public import mir.stat.distribution.binomial: binomialInvCDF;
 ///
 public import mir.stat.distribution.chi2: chi2InvCDF;
 ///
+public import mir.stat.distribution.cornish_fisher: cornishFisherInvCDF;
+///
 public import mir.stat.distribution.exponential: exponentialInvCDF;
 ///
 public import mir.stat.distribution.gamma: gammaInvCDF;

--- a/source/mir/stat/distribution/package.d
+++ b/source/mir/stat/distribution/package.d
@@ -22,6 +22,8 @@ public import mir.stat.distribution.binomial;
 ///
 public import mir.stat.distribution.chi2;
 ///
+public import mir.stat.distribution.cornish_fisher;
+///
 public import mir.stat.distribution.exponential;
 ///
 public import mir.stat.distribution.gamma;


### PR DESCRIPTION
Adds the four-parameter Cornish-Fisher expansion, which is by far the most common from what I have seen. Wikipedia lists the five parameter version, but I think the additional value from more than four parameters would be pretty limited at the moment.

The reason I included this with the distributions is that it theoretically is possible to do the same thing for the PDF & CDF. There is R package that does this ([here](https://rdrr.io/github/braverock/factorAnalytics/man/CornishFisher.html)), but I couldn't find references for the exact formulas that they used and it the package is GPL licensed so I didn't feel comfortable using it here. They also use a slightly different formula that accounts for sample size (they also use the four parameter version). My implementation just uses the Wikipedia formula. 